### PR TITLE
Fix atomic_write() to be atomic and not leave temporary files

### DIFF
--- a/fnalcert_tool/utils.py
+++ b/fnalcert_tool/utils.py
@@ -68,7 +68,7 @@ def atomic_write(filename, contents):
     temp_file = tempfile.NamedTemporaryFile(dir=os.path.dirname(filename))
     temp_file.write(contents)
     temp_file.flush()
-    shutil.copy2(temp_file.name, filename)
+    shutil.move(temp_file.name, filename)
 
 def check_response_500(response):
     """ This functions handles the 500 error response from the server"""

--- a/fnalcert_tool/utils.py
+++ b/fnalcert_tool/utils.py
@@ -65,10 +65,10 @@ def format_csr(csr):
 def atomic_write(filename, contents):
     """Write to a temporary file then move it to its final location
     """
-    temp_file = tempfile.NamedTemporaryFile(dir=os.path.dirname(filename))
-    temp_file.write(contents)
-    temp_file.flush()
-    shutil.move(temp_file.name, filename)
+    temp_fd, temp_name = tempfile.mkstemp(dir=os.path.dirname(filename))
+    os.write(temp_fd, contents)
+    os.close(temp_fd)
+    os.rename(temp_name, filename)
 
 def check_response_500(response):
     """ This functions handles the 500 error response from the server"""


### PR DESCRIPTION
I noticed that I had a lot of tmpfiles left around.  This is the fix for that.